### PR TITLE
Fix spelling in impressum

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
       Angaben gemäß § 5 TMG:<br><br>
       Daniel Suhr, HF<br>
 	  ZAW BetrSt Augustdorf<br>
-      Genral Feldmarschall Rommel Kaserne<br>
+      General Feldmarschall Rommel Kaserne<br>
 	  Von Boselager Straße 212 <br>
       32832 Augustdorf<br>
       Deutschland


### PR DESCRIPTION
## Summary
- correct name for the Rommel Kaserne in the Impressum section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840105cdd788322bd1e0b638a79587c