### PR TITLE
Fix chart title context

### DIFF
--- a/index.html
+++ b/index.html
@@ -1011,7 +1011,7 @@ window.woundChartInstance = new Chart(ctx, {
       legend: { display: false },
       title: {
         display: true,
-        text: 'Wound Distribution (10,000 rolls)'
+        text: 'Wound Distribution'
       }
     },
     scales: {
@@ -1437,7 +1437,7 @@ window.woundChartInstance = new Chart(ctx, {
       legend: { display: false },
       title: {
         display: true,
-        text: 'Wound Distribution (10,000 rolls)'
+        text: 'Wound Distribution'
       }
     },
     scales: {


### PR DESCRIPTION
## Summary
- remove `(10,000 rolls)` from chart titles so they always read "Wound Distribution"

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684011c62a948322a5bb7af261c52837