### PR TITLE
Add attacker rule UI helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,6 +333,44 @@ const numericRangedRules = {};
 const activeMagicRules = new Set();
 const numericMagicRules = {};
 
+function addRuleToUI(key, labelText, type) {
+  const list = document.getElementById("attackerRulesList");
+  const existing = document.getElementById("att_rule_" + key);
+  if (existing) existing.remove();
+
+  const li = document.createElement("li");
+  li.id = "att_rule_" + key;
+  li.style.marginBottom = "5px";
+
+  const label = document.createElement("span");
+  label.textContent = labelText + " ";
+
+  const removeBtn = document.createElement("button");
+  removeBtn.textContent = "❌";
+  removeBtn.style.marginLeft = "10px";
+  removeBtn.onclick = () => {
+    if (type === "toggle") activeAttackerRules.delete(key);
+    if (type === "numeric") delete numericAttackerRules[key];
+
+    if (key === "blessed") {
+      document.getElementById("blessedUsageContainer").style.display = "none";
+    } else if (key === "flawless") {
+      document.getElementById("flawlessConfigContainer").style.display = "none";
+    } else if (key === "relentless") {
+      document.getElementById("relentlessConfigContainer").style.display = "none";
+    } else if (key === "barrage") {
+      document.getElementById("rangedRuleSection").style.display = "none";
+    } else if (key === "priest") {
+      document.getElementById("magicRuleSection").style.display = "none";
+    }
+
+    li.remove();
+  };
+
+  li.appendChild(label);
+  li.appendChild(removeBtn);
+  list.appendChild(li);
+}
 
 
 function addAttackerRule() {


### PR DESCRIPTION
## Summary
- add `addRuleToUI` helper for attacker rules
- helper creates list entries and hides UI sections when a rule is removed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e0355ad083229f111b5b48b30ac7