### PR TITLE
Fix Chart block and function placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -1079,6 +1079,30 @@ window.woundChartInstance = new Chart(ctx, {
     labels: sortedKeys,
     datasets: [{
       label: 'Wound Frequency',
+      data: frequencies,
+      backgroundColor: '#4caf50'
+    }]
+  },
+  options: {
+    responsive: true,
+    plugins: {
+      legend: { display: false },
+      title: {
+        display: true,
+        text: 'Wound Distribution'
+      }
+    },
+    scales: {
+      x: {
+        title: { display: true, text: 'Wounds' }
+      },
+      y: {
+        title: { display: true, text: 'Frequency' },
+        beginAtZero: true
+      }
+    }
+  }
+});
 function runMonteCarloSimulation() {
   const iterations = 10000;
   const results = [];


### PR DESCRIPTION
## Summary
- close dataset configuration block for wound chart
- start `runMonteCarloSimulation()` only after the chart options are closed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e39bcdb483228fef53e1a9f63627