### PR TITLE
Restore calculate button

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,28 @@
 <!-- Display selected rules -->
 <ul id="defenderRulesList" style="margin-top: 10px; list-style: none; padding: 0;"></ul>
 
+<!-- Conditional input for Blessed Usage -->
+<div id="defenderBlessedContainer" style="display: none; margin-top: 10px;">
+  <label for="defenderBlessed">Blessed Usage:</label>
+  <select id="defenderBlessed">
+    <option value="none">None</option>
+    <option value="normal">Normal Attack</option>
+    <option value="impact">Impact Attack</option>
+  </select>
+</div>
+      </div>
+    </div>
+
+    <div class="section">
+      <button onclick="calculateDamage()">Calculate Damage</button>
+          <label><input type="checkbox" id="useSimulation" checked> Use Simulation (10,000 rolls)</label>
+    </div>
+
+    <div class="result" id="result"></div>
+        <canvas id="woundChart" style="max-width: 1000px; margin-top: 30px;"></canvas>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
 <script>
   function openImpressum() {
     document.getElementById("impressumModal").style.display = "block";


### PR DESCRIPTION
## Summary
- restore 'Calculate Damage' button with simulation checkbox
- add missing defender blessed usage dropdown
- add result container and wound chart canvas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879293a987c8322a5adb644fa76f251