### PR TITLE
Fix undefined variable in simulation

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -31,7 +31,8 @@ const priest = numericAttackerRules['priest'] || 0;
   const clash = +document.getElementById('cllash').value;
 const inspired = document.getElementById('inspired').checked;
 const leader = document.getElementById('leader').checked;
-const support = +document.getElementById('support').value; 
+const support = +document.getElementById('support').value;
+const linebreaker = isRuleActive('linebreaker');
 
 
 


### PR DESCRIPTION
## Summary
- define the `linebreaker` rule in `runMonteCarloSimulation`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879d189d4508322844d4a23d14b5c02