### PR TITLE
Fix variable initialization for resolve step

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -120,7 +120,7 @@ const rerollSixes = inspired && clash + 1 > 4;
 
 for (let i = 0; i < iterations; i++) {
   let simWounds = 0;
-
+  let failedResolve = 0;
 
 // Angriff
 let flawlessHits = 0;
@@ -288,7 +288,6 @@ for (let j = 0; j < totalImpact; j++) {
 
     const tenaciousMagic = Math.min(failedMagic, tenacious);
     failedMagic -= tenaciousMagic;
-let failedResolve = 0;
 
 let failedMagicResolve = 0;
 if (priest > 0 && magicHits > 0 && !noResolveSpell && !insanityKheres) {


### PR DESCRIPTION
## Summary
- define `failedResolve` at the start of each simulation iteration
- remove duplicate declaration later in the simulation

This prevents `failedResolve` from being undefined during the Monte Carlo simulation.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879dcb518808322aec434b775ed4ae5