### PR TITLE
Fix Monte Carlo simulation loop

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -426,14 +426,14 @@ failedResolve = Math.max(0, failedResolve - indomitable);
 const resolveWounds = oblivious ? Math.ceil(failedResolve / 2) : failedResolve;
 
     // === Total ===
-    simWounds = failedSaves + failedFlawless + failedImpact + failedTrample + resolveWounds + barrageWounds;
+  simWounds = failedSaves + failedFlawless + failedImpact + failedTrample + resolveWounds + barrageWounds;
     results.push(simWounds);
+  }
 
   results.sort((a, b) => a - b);
   const avg = results.reduce((a, b) => a + b, 0) / iterations;
   const median = results[Math.floor(results.length / 2)];
   const mode = results.sort((a, b) =>
-  
     results.filter(v => v === a).length - results.filter(v => v === b).length
   ).pop();
 
@@ -492,7 +492,6 @@ window.woundChartInstance = new Chart(ctx, {
     }
   }
   });
-}
 }
 
 window.runMonteCarloSimulation = runMonteCarloSimulation;


### PR DESCRIPTION
## Summary
- close the Monte Carlo iteration loop before sorting
- compute statistics and chart after the loop

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_e_6879fb0ce6308322859f8d5062b6fcb0