### PR TITLE
Fix resolve for trample

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -261,9 +261,9 @@ for (let j = 0; j < totalImpact; j++) {
     const tenaciousTrample = Math.min(failedTrample, tenacious);
     failedTrample -= tenaciousTrample;
 
-    // === Resolve for melee/impact/trample ===
+    // === Resolve for melee/impact (Trample causes no Resolve) ===
     if (!ignoreResolve) {
-      const totalFailed = failedSaves + failedFlawless + failedImpact + failedTrample;
+      const totalFailed = failedSaves + failedFlawless + failedImpact;
       for (let j = 0; j < totalFailed; j++) {
         let roll = Math.ceil(Math.random() * 6);
         let success = roll <= resolveTarget;


### PR DESCRIPTION
## Summary
- exclude trample hits from resolve checks in the Monte Carlo simulation

## Testing
- `node --check simulation.js`
- `node --check calculator.js`


------
https://chatgpt.com/codex/tasks/task_e_687a0478de48832295e6be3ba13696c9