### PR TITLE
Fix magic damage calculation in simulation

### DIFF
--- a/simulation.js
+++ b/simulation.js
@@ -472,7 +472,9 @@ const resolveWounds = oblivious ? Math.ceil(failedResolve / 2) : failedResolve;
   totalFailedResolve += iterationFailedResolve;
 
     // === Total ===
-  simWounds = failedSaves + failedFlawless + failedImpact + failedTrample + resolveWounds + barrageWounds;
+  const resolveWoundsMagic = oblivious ? Math.ceil(failedMagicResolve / 2) : failedMagicResolve;
+  simWounds = failedSaves + failedFlawless + failedImpact + failedTrample +
+    resolveWounds + failedMagic + resolveWoundsMagic + barrageWounds;
     results.push(simWounds);
   }
 


### PR DESCRIPTION
## Summary
- add magic save and resolve wounds to total damage

## Testing
- `node -c simulation.js`

------
https://chatgpt.com/codex/tasks/task_e_687a0602e9c08322a4114fd77da3b1b6